### PR TITLE
fix: Enable whitespace in BillToName

### DIFF
--- a/src/classes/BaseCmiClient.ts
+++ b/src/classes/BaseCmiClient.ts
@@ -137,7 +137,7 @@ export default class BaseCmiClient implements CmiClientinterface {
         validLang: ['ar', 'fr', 'en'],
       },
       { field: 'email', required: true, type: 'stringOrNull', allowEmpty: false, noWhitespace: true, isEmail: true },
-      { field: 'BillToName', required: true, type: 'stringOrNull', allowEmpty: false, noWhitespace: true },
+      { field: 'BillToName', required: true, type: 'stringOrNull', allowEmpty: false, noWhitespace: false },
       {
         field: 'hashAlgorithm',
         required: true,


### PR DESCRIPTION
Hi from Morocco,

this PR fixes the bug "Error: BillToName can't contain whitespace", because the full name can be with white space in almost all cases